### PR TITLE
docs: use new config connectionName instand of old config useNewUrlParser

### DIFF
--- a/libs/nestjs-typegoose/README.md
+++ b/libs/nestjs-typegoose/README.md
@@ -45,9 +45,7 @@ import { CatsModule } from "./cat.module.ts";
 
 @Module({
   imports: [
-    TypegooseModule.forRoot("mongodb://localhost:27017/nest", {
-      connectionName: 'default',
-    }),
+    TypegooseModule.forRoot("mongodb://localhost:27017/nest"),
     CatsModule,
   ],
 })

--- a/libs/nestjs-typegoose/README.md
+++ b/libs/nestjs-typegoose/README.md
@@ -46,7 +46,7 @@ import { CatsModule } from "./cat.module.ts";
 @Module({
   imports: [
     TypegooseModule.forRoot("mongodb://localhost:27017/nest", {
-      useNewUrlParser: true,
+      connectionName: 'default',
     }),
     CatsModule,
   ],

--- a/libs/nestjs-typegoose/example/src/app.module.ts
+++ b/libs/nestjs-typegoose/example/src/app.module.ts
@@ -6,9 +6,7 @@ import { CatsModule } from './cat/cats.module'
 
 @Module({
   imports: [
-    TypegooseModule.forRoot('mongodb://localhost:27017/nest', {
-      useNewUrlParser: true
-    }),
+    TypegooseModule.forRoot('mongodb://localhost:27017/nest'),
     CatsModule
   ],
   controllers: [AppController],

--- a/libs/nestjs-typegoose/website/docs/usage.md
+++ b/libs/nestjs-typegoose/website/docs/usage.md
@@ -26,9 +26,7 @@ import { CatsModule } from "./cat.module.ts";
 
 @Module({
   imports: [
-    TypegooseModule.forRoot("mongodb://localhost:27017/nest", {
-      useNewUrlParser: true
-    }),
+    TypegooseModule.forRoot("mongodb://localhost:27017/nest"),
     CatsModule
   ]
 })


### PR DESCRIPTION
current version no has useNewUrlParser config in TypegooseConnectionOptions

![image](https://github.com/m8a-io/m8a/assets/43949542/8ec3a584-e956-4e58-8417-760c943ddab2)

update config to use connectionName instand of useNewUrlParser

![image](https://github.com/m8a-io/m8a/assets/43949542/fc02b2ca-de18-493f-9817-8a7c7ca02881)
